### PR TITLE
feature/split commands to packages

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,6 +83,46 @@ func main() {
 					return nil
 				},
 			},
+			{
+				Name:      "run-task",
+				Usage:     "run a single Blast task",
+				ArgsUsage: "[path to the task file]",
+				Action: func(c *cli.Context) error {
+					errorPrinter := color.New(color.FgRed, color.Bold)
+
+					taskPath := c.Args().Get(0)
+					if taskPath == "" {
+						errorPrinter.Printf("Please give a task path: blast-cli run-task <path to the task definition>)\n")
+						return cli.Exit("", 1)
+					}
+
+					builderConfig := pipeline.BuilderConfig{
+						PipelineFileName:   pipelineDefinitionFile,
+						TasksDirectoryName: defaultTasksPath,
+						TasksFileName:      defaultTaskFileName,
+					}
+					builder := pipeline.NewBuilder(builderConfig, pipeline.CreateTaskFromYamlDefinition, pipeline.CreateTaskFromFileComments)
+
+					task, err := builder.CreateTaskFromFile(taskPath)
+					if err != nil {
+						errorPrinter.Printf("Failed to build task: %v\n", err.Error())
+						return cli.Exit("", 1)
+					}
+
+					if task == nil {
+						errorPrinter.Printf("The given file path doesn't seem to be a Blast task definition: '%s'\n", taskPath)
+						return cli.Exit("", 1)
+					}
+
+					_, err = path.GetPipelinePathFromTask(taskPath, pipelineDefinitionFile)
+					if err != nil {
+						errorPrinter.Printf("Failed to find the pipeline this task belongs to: '%s'\n", taskPath)
+						return cli.Exit("", 1)
+					}
+
+					return nil
+				},
+			},
 		},
 	}
 

--- a/pkg/bigquery/db.go
+++ b/pkg/bigquery/db.go
@@ -66,3 +66,22 @@ func (d DB) IsValid(ctx context.Context, query *query.Query) (bool, error) {
 
 	return true, nil
 }
+
+func (d DB) RunQueryWithoutResult(ctx context.Context, query *query.Query) error {
+	q := d.client.Query(query.String())
+	_, err := q.Read(ctx)
+	if err != nil {
+		var googleError *googleapi.Error
+		if !errors.As(err, &googleError) {
+			return err
+		}
+
+		if googleError.Code == 404 {
+			return fmt.Errorf("%s", googleError.Message)
+		}
+
+		return googleError
+	}
+
+	return nil
+}

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -262,7 +262,7 @@ func TestDB_RunQueryWithoutResult(t *testing.T) {
 					return
 				}
 
-				w.WriteHeader(500)
+				w.WriteHeader(http.StatusInternalServerError)
 				_, err := w.Write([]byte("there is no test definition found for the given request"))
 				assert.NoError(t, err)
 			}))

--- a/pkg/bigquery/db_test.go
+++ b/pkg/bigquery/db_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -138,6 +140,156 @@ func TestDB_IsValid(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDB_RunQueryWithoutResult(t *testing.T) {
+	t.Parallel()
+
+	projectID := "test-project"
+	jobID := "test-job"
+
+	type jobSubmitResponse struct {
+		response   any
+		statusCode int
+	}
+
+	type queryResultResponse struct {
+		response   *bigquery2.GetQueryResultsResponse
+		statusCode int
+	}
+
+	tests := []struct {
+		name                string
+		query               string
+		jobSubmitResponse   jobSubmitResponse
+		queryResultResponse queryResultResponse
+		err                 error
+	}{
+		{
+			name:  "bad request",
+			query: "select * from users",
+			jobSubmitResponse: jobSubmitResponse{
+				response:   &bigquery2.Job{},
+				statusCode: http.StatusBadRequest,
+			},
+			err: &googleapi.Error{
+				Code: 400,
+				Body: "{}",
+			},
+		},
+		{
+			name:  "Google API returns 404",
+			query: "select * from users",
+			jobSubmitResponse: jobSubmitResponse{
+				response: map[string]interface{}{
+					"error": googleapi.Error{
+						Code:    404,
+						Message: "not found: Table project:schema.table was not found in location ABC",
+						Errors: []googleapi.ErrorItem{
+							{
+								Reason:  "notFound",
+								Message: "not found: Table project:schema.table was not found in location ABC",
+							},
+						},
+					},
+				},
+				statusCode: http.StatusNotFound,
+			},
+			err: errors.New("not found: Table project:schema.table was not found in location ABC"),
+		},
+		{
+			name:  "no error returned",
+			query: "select * from users",
+			jobSubmitResponse: jobSubmitResponse{
+				response: &bigquery2.Job{
+					Configuration: &bigquery2.JobConfiguration{
+						Query: &bigquery2.JobConfigurationQuery{
+							Query: "select * from users",
+							DestinationTable: &bigquery2.TableReference{
+								ProjectId: projectID,
+								DatasetId: "test-dataset",
+							},
+						},
+					},
+					JobReference: &bigquery2.JobReference{
+						JobId:     jobID,
+						ProjectId: projectID,
+					},
+					Status: &bigquery2.JobStatus{
+						State:  "DONE",
+						Errors: nil,
+					},
+				},
+				statusCode: http.StatusOK,
+			},
+			queryResultResponse: queryResultResponse{
+				response: &bigquery2.GetQueryResultsResponse{
+					JobReference: &bigquery2.JobReference{
+						JobId: "job-id",
+					},
+					JobComplete: true,
+				},
+				statusCode: http.StatusOK,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == "GET" && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/queries/%s?", projectID, jobID)) {
+					w.WriteHeader(tt.queryResultResponse.statusCode)
+
+					response, err := json.Marshal(tt.queryResultResponse.response)
+					assert.NoError(t, err)
+
+					_, err = w.Write(response)
+					assert.NoError(t, err)
+					return
+				} else if r.Method == "POST" && strings.HasPrefix(r.RequestURI, fmt.Sprintf("/projects/%s/jobs", projectID)) {
+					w.WriteHeader(tt.jobSubmitResponse.statusCode)
+
+					response, err := json.Marshal(tt.jobSubmitResponse.response)
+					assert.NoError(t, err)
+
+					_, err = w.Write(response)
+					assert.NoError(t, err)
+					return
+				}
+
+				w.WriteHeader(500)
+				_, err := w.Write([]byte("there is no test definition found for the given request"))
+				assert.NoError(t, err)
+			}))
+			defer server.Close()
+
+			client, err := bigquery.NewClient(
+				context.Background(),
+				projectID,
+				option.WithEndpoint(server.URL),
+				option.WithCredentials(&google.Credentials{
+					ProjectID: projectID,
+					TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
+						AccessToken: "some-token",
+					}),
+				}),
+			)
+			assert.NoError(t, err)
+			client.Location = "US"
+
+			d := DB{client: client}
+
+			err = d.RunQueryWithoutResult(context.Background(), &query.Query{Query: tt.query})
+			if tt.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err.Error())
+			}
 		})
 	}
 }

--- a/pkg/bigquery/operator.go
+++ b/pkg/bigquery/operator.go
@@ -1,0 +1,42 @@
+package bigquery
+
+import (
+	"context"
+
+	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
+	"github.com/datablast-analytics/blast-cli/pkg/query"
+	"github.com/pkg/errors"
+)
+
+type querier interface {
+	RunQueryWithoutResult(ctx context.Context, q *query.Query) error
+}
+
+type queryExtractor interface {
+	ExtractQueriesFromFile(filepath string) ([]*query.Query, error)
+}
+
+type BasicOperator struct {
+	client    querier
+	extractor queryExtractor
+}
+
+func NewBasicOperator(client *DB, extractor queryExtractor) *BasicOperator {
+	return &BasicOperator{
+		client:    client,
+		extractor: extractor,
+	}
+}
+
+func (o BasicOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Task) error {
+	queries, err := o.extractor.ExtractQueriesFromFile(t.ExecutableFile.Path)
+	if err != nil {
+		return errors.Wrap(err, "cannot extract queries from the task file")
+	}
+
+	if len(queries) == 0 {
+		return nil
+	}
+
+	return o.client.RunQueryWithoutResult(ctx, queries[0])
+}

--- a/pkg/bigquery/operator_test.go
+++ b/pkg/bigquery/operator_test.go
@@ -1,0 +1,147 @@
+package bigquery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
+	"github.com/datablast-analytics/blast-cli/pkg/query"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockQuerier struct {
+	mock.Mock
+}
+
+func (m *mockQuerier) RunQueryWithoutResult(ctx context.Context, q *query.Query) error {
+	args := m.Called(ctx, q)
+	return args.Error(0)
+}
+
+type mockExtractor struct {
+	mock.Mock
+}
+
+func (m *mockExtractor) ExtractQueriesFromFile(filepath string) ([]*query.Query, error) {
+	res := m.Called(filepath)
+	return res.Get(0).([]*query.Query), res.Error(1)
+}
+
+func TestBasicOperator_RunTask(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		t *pipeline.Task
+	}
+
+	tests := []struct {
+		name           string
+		setupQueries   func(m *mockQuerier)
+		setupExtractor func(m *mockExtractor)
+		args           args
+		wantErr        bool
+	}{
+		{
+			name: "failed to extract queries",
+			setupExtractor: func(m *mockExtractor) {
+				m.On("ExtractQueriesFromFile", "test-file.sql").
+					Return([]*query.Query{}, errors.New("failed to extract queries"))
+			},
+			args: args{
+				t: &pipeline.Task{
+					ExecutableFile: pipeline.ExecutableFile{
+						Path: "test-file.sql",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no queries found in file",
+			setupExtractor: func(m *mockExtractor) {
+				m.On("ExtractQueriesFromFile", "test-file.sql").
+					Return([]*query.Query{}, nil)
+			},
+			args: args{
+				t: &pipeline.Task{
+					ExecutableFile: pipeline.ExecutableFile{
+						Path: "test-file.sql",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "query returned an error",
+			setupExtractor: func(m *mockExtractor) {
+				m.On("ExtractQueriesFromFile", "test-file.sql").
+					Return([]*query.Query{
+						{Query: "select * from users"},
+					}, nil)
+			},
+			setupQueries: func(m *mockQuerier) {
+				m.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "select * from users"}).
+					Return(errors.New("failed to run query"))
+			},
+			args: args{
+				t: &pipeline.Task{
+					ExecutableFile: pipeline.ExecutableFile{
+						Path: "test-file.sql",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "query successfully executed",
+			setupExtractor: func(m *mockExtractor) {
+				m.On("ExtractQueriesFromFile", "test-file.sql").
+					Return([]*query.Query{
+						{Query: "select * from users"},
+					}, nil)
+			},
+			setupQueries: func(m *mockQuerier) {
+				m.On("RunQueryWithoutResult", mock.Anything, &query.Query{Query: "select * from users"}).
+					Return(nil)
+			},
+			args: args{
+				t: &pipeline.Task{
+					ExecutableFile: pipeline.ExecutableFile{
+						Path: "test-file.sql",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := new(mockQuerier)
+			if tt.setupQueries != nil {
+				tt.setupQueries(client)
+			}
+
+			extractor := new(mockExtractor)
+			if tt.setupExtractor != nil {
+				tt.setupExtractor(extractor)
+			}
+
+			o := BasicOperator{
+				client:    client,
+				extractor: extractor,
+			}
+
+			err := o.RunTask(context.Background(), &pipeline.Pipeline{}, tt.args.t)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/executor/sequential.go
+++ b/pkg/executor/sequential.go
@@ -7,15 +7,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-type operator interface {
-	RunTask(ctx context.Context, p pipeline.Pipeline, t pipeline.Task) error
+type Operator interface {
+	RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Task) error
 }
 
 type Sequential struct {
-	TaskTypeMap map[string]operator
+	TaskTypeMap map[string]Operator
 }
 
-func (l Sequential) RunSingleTask(ctx context.Context, pipeline pipeline.Pipeline, task pipeline.Task) error {
+func (l Sequential) RunSingleTask(ctx context.Context, pipeline *pipeline.Pipeline, task *pipeline.Task) error {
 	// check if task type exists in map
 	if _, ok := l.TaskTypeMap[task.Type]; !ok {
 		return errors.New("there is no executor configured for the task type, task cannot be run: " + task.Type)

--- a/pkg/executor/sequential.go
+++ b/pkg/executor/sequential.go
@@ -1,23 +1,25 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
 	"github.com/pkg/errors"
 )
 
 type operator interface {
-	RunTask(p pipeline.Pipeline, t pipeline.Task) error
+	RunTask(ctx context.Context, p pipeline.Pipeline, t pipeline.Task) error
 }
 
 type Sequential struct {
 	TaskTypeMap map[string]operator
 }
 
-func (l Sequential) RunSingleTask(pipeline pipeline.Pipeline, task pipeline.Task) error {
+func (l Sequential) RunSingleTask(ctx context.Context, pipeline pipeline.Pipeline, task pipeline.Task) error {
 	// check if task type exists in map
 	if _, ok := l.TaskTypeMap[task.Type]; !ok {
 		return errors.New("there is no executor configured for the task type, task cannot be run: " + task.Type)
 	}
 
-	return l.TaskTypeMap[task.Type].RunTask(pipeline, task)
+	return l.TaskTypeMap[task.Type].RunTask(ctx, pipeline, task)
 }

--- a/pkg/executor/sequential.go
+++ b/pkg/executor/sequential.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
+	"github.com/pkg/errors"
+)
+
+type operator interface {
+	RunTask(p pipeline.Pipeline, t pipeline.Task) error
+}
+
+type Sequential struct {
+	TaskTypeMap map[string]operator
+}
+
+func (l Sequential) RunSingleTask(pipeline pipeline.Pipeline, task pipeline.Task) error {
+	// check if task type exists in map
+	if _, ok := l.TaskTypeMap[task.Type]; !ok {
+		return errors.New("there is no executor configured for the task type, task cannot be run: " + task.Type)
+	}
+
+	return l.TaskTypeMap[task.Type].RunTask(pipeline, task)
+}

--- a/pkg/executor/sequential_test.go
+++ b/pkg/executor/sequential_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
@@ -13,8 +14,8 @@ type mockOperator struct {
 	mock.Mock
 }
 
-func (d *mockOperator) RunTask(p pipeline.Pipeline, t pipeline.Task) error {
-	args := d.Called(p, t)
+func (d *mockOperator) RunTask(ctx context.Context, p pipeline.Pipeline, t pipeline.Task) error {
+	args := d.Called(ctx, p, t)
 	return args.Error(0)
 }
 
@@ -31,7 +32,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 		t.Parallel()
 
 		mockOperator := new(mockOperator)
-		mockOperator.On("RunTask", p, task).
+		mockOperator.On("RunTask", mock.Anything, p, task).
 			Return(nil)
 
 		l := Sequential{
@@ -40,7 +41,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 			},
 		}
 
-		err := l.RunSingleTask(p, task)
+		err := l.RunSingleTask(context.Background(), p, task)
 
 		assert.NoError(t, err)
 		mockOperator.AssertExpectations(t)
@@ -57,7 +58,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 			},
 		}
 
-		err := l.RunSingleTask(p, task)
+		err := l.RunSingleTask(context.Background(), p, task)
 
 		assert.Error(t, err)
 		mockOperator.AssertExpectations(t)
@@ -67,7 +68,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 		t.Parallel()
 
 		mockOperator := new(mockOperator)
-		mockOperator.On("RunTask", p, task).
+		mockOperator.On("RunTask", mock.Anything, p, task).
 			Return(errors.New("some error occurred"))
 
 		l := Sequential{
@@ -76,7 +77,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 			},
 		}
 
-		err := l.RunSingleTask(p, task)
+		err := l.RunSingleTask(context.Background(), p, task)
 
 		assert.Error(t, err)
 		mockOperator.AssertExpectations(t)

--- a/pkg/executor/sequential_test.go
+++ b/pkg/executor/sequential_test.go
@@ -14,7 +14,7 @@ type mockOperator struct {
 	mock.Mock
 }
 
-func (d *mockOperator) RunTask(ctx context.Context, p pipeline.Pipeline, t pipeline.Task) error {
+func (d *mockOperator) RunTask(ctx context.Context, p *pipeline.Pipeline, t *pipeline.Task) error {
 	args := d.Called(ctx, p, t)
 	return args.Error(0)
 }
@@ -22,8 +22,8 @@ func (d *mockOperator) RunTask(ctx context.Context, p pipeline.Pipeline, t pipel
 func TestLocal_RunSingleTask(t *testing.T) {
 	t.Parallel()
 
-	p := pipeline.Pipeline{}
-	task := pipeline.Task{
+	p := &pipeline.Pipeline{}
+	task := &pipeline.Task{
 		Name: "task1",
 		Type: "test",
 	}
@@ -36,7 +36,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 			Return(nil)
 
 		l := Sequential{
-			TaskTypeMap: map[string]operator{
+			TaskTypeMap: map[string]Operator{
 				"test": mockOperator,
 			},
 		}
@@ -53,7 +53,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 		mockOperator := new(mockOperator)
 
 		l := Sequential{
-			TaskTypeMap: map[string]operator{
+			TaskTypeMap: map[string]Operator{
 				"some-other-task": mockOperator,
 			},
 		}
@@ -72,7 +72,7 @@ func TestLocal_RunSingleTask(t *testing.T) {
 			Return(errors.New("some error occurred"))
 
 		l := Sequential{
-			TaskTypeMap: map[string]operator{
+			TaskTypeMap: map[string]Operator{
 				"test": mockOperator,
 			},
 		}

--- a/pkg/executor/sequential_test.go
+++ b/pkg/executor/sequential_test.go
@@ -1,0 +1,84 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/datablast-analytics/blast-cli/pkg/pipeline"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockOperator struct {
+	mock.Mock
+}
+
+func (d *mockOperator) RunTask(p pipeline.Pipeline, t pipeline.Task) error {
+	args := d.Called(p, t)
+	return args.Error(0)
+}
+
+func TestLocal_RunSingleTask(t *testing.T) {
+	t.Parallel()
+
+	p := pipeline.Pipeline{}
+	task := pipeline.Task{
+		Name: "task1",
+		Type: "test",
+	}
+
+	t.Run("simple task is executed successfully", func(t *testing.T) {
+		t.Parallel()
+
+		mockOperator := new(mockOperator)
+		mockOperator.On("RunTask", p, task).
+			Return(nil)
+
+		l := Sequential{
+			TaskTypeMap: map[string]operator{
+				"test": mockOperator,
+			},
+		}
+
+		err := l.RunSingleTask(p, task)
+
+		assert.NoError(t, err)
+		mockOperator.AssertExpectations(t)
+	})
+
+	t.Run("missing task is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		mockOperator := new(mockOperator)
+
+		l := Sequential{
+			TaskTypeMap: map[string]operator{
+				"some-other-task": mockOperator,
+			},
+		}
+
+		err := l.RunSingleTask(p, task)
+
+		assert.Error(t, err)
+		mockOperator.AssertExpectations(t)
+	})
+
+	t.Run("missing task is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		mockOperator := new(mockOperator)
+		mockOperator.On("RunTask", p, task).
+			Return(errors.New("some error occurred"))
+
+		l := Sequential{
+			TaskTypeMap: map[string]operator{
+				"test": mockOperator,
+			},
+		}
+
+		err := l.RunSingleTask(p, task)
+
+		assert.Error(t, err)
+		mockOperator.AssertExpectations(t)
+	})
+}

--- a/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/pipeline.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/pipeline.yml
@@ -1,0 +1,13 @@
+name: first-pipeline
+schedule: ""
+default_args:
+    owner: "some.user"
+    depends_on_past: false
+    start_date: "2021-01-01"
+    email: ["user@example.com"]
+    email_on_failure: false
+    email_on_retry: false
+    retries: 1
+default_connections:
+    slack: "slack-connection"
+    gcpConnectionId: "gcp-connection-id-here"

--- a/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/hello.sh
+++ b/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/hello.sh
@@ -1,0 +1,1 @@
+echo "hello world from test script"

--- a/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/task.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/task.yml
@@ -1,0 +1,5 @@
+name: hello-world
+type: bash
+run: hello.sh
+depends:
+  - gcs-to-bq

--- a/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/test1/task.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/test1/task.yml
@@ -1,0 +1,6 @@
+name: gcs-to-bq
+type: bq.transfer
+parameters:
+  transfer_config_id: some-uuid
+  project_id: "some-project-id"
+  location: "europe-west1"

--- a/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/test2/task.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/first-pipeline/tasks/test2/task.yml
@@ -1,0 +1,6 @@
+name: gcs-to-bq-2
+type: bq.transfer
+parameters:
+  transfer_config_id: "some-uuid"
+  project_id: "a-new-project-id"
+  location: "europe-west1"

--- a/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/pipeline.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/pipeline.yml
@@ -1,0 +1,13 @@
+name: first-pipeline
+schedule: ""
+default_args:
+    owner: "some.user"
+    depends_on_past: false
+    start_date: "2021-01-01"
+    email: ["user@example.com"]
+    email_on_failure: false
+    email_on_retry: false
+    retries: 1
+default_connections:
+    slack: "slack-connection"
+    gcpConnectionId: "gcp-connection-id-here"

--- a/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/tasks/task1.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/tasks/task1.yml
@@ -1,0 +1,6 @@
+name: gcs-to-bq
+type: bq.transfer
+parameters:
+  transfer_config_id: some-uuid
+  project_id: "some-project-id"
+  location: "europe-west1"

--- a/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/tasks/test2/task.yml
+++ b/pkg/path/testdata/walk/task-to-pipeline/second-pipeline/tasks/test2/task.yml
@@ -1,0 +1,6 @@
+name: gcs-to-bq-2
+type: bq.transfer
+parameters:
+  transfer_config_id: "some-uuid"
+  project_id: "a-new-project-id"
+  location: "europe-west1"

--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -38,7 +38,7 @@ func GetPipelinePaths(root, pipelineDefinitionFile string) ([]string, error) {
 	return pipelinePaths, nil
 }
 
-func GetPipelinePathFromTask(taskPath, pipelineDefinitionFile string) (string, error) {
+func GetPipelineRootFromTask(taskPath, pipelineDefinitionFile string) (string, error) {
 	absoluteTaskPath, err := filepath.Abs(taskPath)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert task path to absolute path")
@@ -48,7 +48,7 @@ func GetPipelinePathFromTask(taskPath, pipelineDefinitionFile string) (string, e
 	for currentFolder != "/" {
 		tryPath := filepath.Join(currentFolder, pipelineDefinitionFile)
 		if _, err := os.Stat(tryPath); err == nil {
-			return tryPath, nil
+			return currentFolder, nil
 		}
 
 		currentFolder = filepath.Dir(currentFolder)

--- a/pkg/path/walk.go
+++ b/pkg/path/walk.go
@@ -2,6 +2,7 @@ package path
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -35,6 +36,25 @@ func GetPipelinePaths(root, pipelineDefinitionFile string) ([]string, error) {
 	}
 
 	return pipelinePaths, nil
+}
+
+func GetPipelinePathFromTask(taskPath, pipelineDefinitionFile string) (string, error) {
+	absoluteTaskPath, err := filepath.Abs(taskPath)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to convert task path to absolute path")
+	}
+
+	currentFolder := filepath.Dir(absoluteTaskPath)
+	for currentFolder != "/" {
+		tryPath := filepath.Join(currentFolder, pipelineDefinitionFile)
+		if _, err := os.Stat(tryPath); err == nil {
+			return tryPath, nil
+		}
+
+		currentFolder = filepath.Dir(currentFolder)
+	}
+
+	return "", errors.New("cannot find a pipeline the given task belongs to, are you sure this task is in an actual pipeline?")
 }
 
 func GetAllFilesRecursive(root string) ([]string, error) {

--- a/pkg/path/walk_test.go
+++ b/pkg/path/walk_test.go
@@ -55,6 +55,64 @@ func TestGetPipelinePaths(t *testing.T) {
 	}
 }
 
+func TestGetPipelinePathFromTask(t *testing.T) {
+	t.Parallel()
+
+	firstPipelineAbsolute, err := filepath.Abs("testdata/walk/task-to-pipeline/first-pipeline")
+	require.NoError(t, err)
+
+	secondPipelineAbsolute, err := filepath.Abs("testdata/walk/task-to-pipeline/second-pipeline")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name                   string
+		taskPath               string
+		pipelineDefinitionFile string
+		want                   string
+		wantErr                bool
+	}{
+		{
+			name:                   "pipeline is found from a deeply nested task",
+			taskPath:               "testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/task.yml",
+			pipelineDefinitionFile: "pipeline.yml",
+			want:                   filepath.Join(firstPipelineAbsolute, "pipeline.yml"),
+		},
+		{
+			name:                   "pipeline is found from a shallow nested task",
+			taskPath:               "testdata/walk/task-to-pipeline/second-pipeline/tasks/task1.yml",
+			pipelineDefinitionFile: "pipeline.yml",
+			want:                   filepath.Join(secondPipelineAbsolute, "pipeline.yml"),
+		},
+		{
+			name:                   "pipeline is found even if definition file name is different",
+			taskPath:               "testdata/walk/task-to-pipeline/second-pipeline/tasks/test2/task.yml",
+			pipelineDefinitionFile: "task1.yml",
+			want:                   filepath.Join(secondPipelineAbsolute, "tasks/task1.yml"),
+		},
+		{
+			name:                   "an error is returned when the pipeline is not found",
+			taskPath:               "testdata",
+			pipelineDefinitionFile: "pipeline.yml",
+			wantErr:                true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := GetPipelinePathFromTask(tt.taskPath, tt.pipelineDefinitionFile)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPipelinePaths() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetAllFilesRecursive(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/path/walk_test.go
+++ b/pkg/path/walk_test.go
@@ -55,7 +55,7 @@ func TestGetPipelinePaths(t *testing.T) {
 	}
 }
 
-func TestGetPipelinePathFromTask(t *testing.T) {
+func TestGetPipelineRootFromTask(t *testing.T) {
 	t.Parallel()
 
 	firstPipelineAbsolute, err := filepath.Abs("testdata/walk/task-to-pipeline/first-pipeline")
@@ -75,19 +75,19 @@ func TestGetPipelinePathFromTask(t *testing.T) {
 			name:                   "pipeline is found from a deeply nested task",
 			taskPath:               "testdata/walk/task-to-pipeline/first-pipeline/tasks/helloworld/task.yml",
 			pipelineDefinitionFile: "pipeline.yml",
-			want:                   filepath.Join(firstPipelineAbsolute, "pipeline.yml"),
+			want:                   firstPipelineAbsolute,
 		},
 		{
 			name:                   "pipeline is found from a shallow nested task",
 			taskPath:               "testdata/walk/task-to-pipeline/second-pipeline/tasks/task1.yml",
 			pipelineDefinitionFile: "pipeline.yml",
-			want:                   filepath.Join(secondPipelineAbsolute, "pipeline.yml"),
+			want:                   secondPipelineAbsolute,
 		},
 		{
 			name:                   "pipeline is found even if definition file name is different",
 			taskPath:               "testdata/walk/task-to-pipeline/second-pipeline/tasks/test2/task.yml",
 			pipelineDefinitionFile: "task1.yml",
-			want:                   filepath.Join(secondPipelineAbsolute, "tasks/task1.yml"),
+			want:                   filepath.Join(secondPipelineAbsolute, "tasks"),
 		},
 		{
 			name:                   "an error is returned when the pipeline is not found",
@@ -101,7 +101,7 @@ func TestGetPipelinePathFromTask(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := GetPipelinePathFromTask(tt.taskPath, tt.pipelineDefinitionFile)
+			got, err := GetPipelineRootFromTask(tt.taskPath, tt.pipelineDefinitionFile)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetPipelinePaths() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/query/extract.go
+++ b/pkg/query/extract.go
@@ -41,6 +41,10 @@ func (q Query) ToDryRunQuery() string {
 	return eq
 }
 
+func (q Query) String() string {
+	return q.Query
+}
+
 var queryCommentRegex = regexp.MustCompile(`(?m)(?s)\/\*.*?\*\/|(^|\s)--.*?\n`)
 
 type renderer interface {


### PR DESCRIPTION
- add a new helper for finding pipeline path relative to a task path
- expose task creator from the builder
- add basic validations for the command
- add a new sequential executor
- add a query runner to bigquery
- introduce context to the executor
- create a simple operator
- expose operator interface
- return pipeline root instead of path
- run single task through a bq project
